### PR TITLE
Add ViPER4AndroidFX integration guide and CI validation

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,4 @@
-name: Makefile CI
+name: Validate prebuilts
 
 on:
   push:
@@ -7,21 +7,44 @@ on:
     branches: [ "bka" ]
 
 jobs:
-  build:
+  validate:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+    - name: Validate required files
+      run: |
+        test -f Android.bp
+        test -f Android.mk
+        test -f config.mk
+        test -f system/app/Android.mk
+        test -f system/app/ViPER4AndroidFX/ViPER4AndroidFX.apk
+        test -f vendor/lib/soundfx/libv4a_re.so
+        test -f vendor/lib64/soundfx/libv4a_re.so
+        test -f sepolicy/audioserver_viper4android.te
 
-    - name: configure
-      run: ./configure
+    - name: Validate artifact formats
+      run: |
+        python3 - <<'PY'
+        from pathlib import Path
 
-    - name: Install dependencies
-      run: make
+        checks = {
+            "system/app/ViPER4AndroidFX/ViPER4AndroidFX.apk": b"PK\x03\x04",
+            "vendor/lib/soundfx/libv4a_re.so": b"\x7fELF",
+            "vendor/lib64/soundfx/libv4a_re.so": b"\x7fELF",
+        }
 
-    - name: Run check
-      run: make check
+        for filename, magic in checks.items():
+            data = Path(filename).read_bytes()
+            if not data.startswith(magic):
+                raise SystemExit(f"{filename} has an unexpected file signature")
+        PY
 
-    - name: Run distcheck
-      run: make distcheck
+    - name: Validate module declarations
+      run: |
+        grep -q 'name: "libv4a_re"' Android.bp
+        grep -q 'vendor: true' Android.bp
+        grep -q 'compile_multilib: "both"' Android.bp
+        grep -q 'LOCAL_MODULE := ViPER4AndroidFX' system/app/Android.mk
+        grep -q 'LOCAL_CERTIFICATE := PRESIGNED' system/app/Android.mk

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,27 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "bka" ]
+  pull_request:
+    branches: [ "bka" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck

--- a/README.md
+++ b/README.md
@@ -1,18 +1,94 @@
 ## ViPER4Android FX
 
-Integrate V4A by completing these three steps:
+This repository contains prebuilt ViPER4Android FX artifacts for integration into an AOSP-based ROM build tree.
 
-1.  **Build System:** Add the config to **`device.mk`**:
+It provides:
 
-    ```makefile
-    $(call inherit-product, packages/apps/ViPER4AndroidFX/config.mk)
-    ```
+- `ViPER4AndroidFX`, a presigned prebuilt system app that overrides `AudioFX`.
+- `libv4a_re`, prebuilt 32-bit and 64-bit vendor sound effect libraries installed under `vendor/lib*/soundfx`.
 
-2.  **SELinux Policy:** Add these rules to your **`audioserver.te`** file:
+## Requirements
 
-    ```
-    get_prop(audioserver, vendor_audio_prop) # If Google or MTK device skip line
+- A working AOSP or custom ROM source tree.
+- This repository checked out at `packages/apps/ViPER4AndroidFX`.
+- A product or device makefile where product packages can be inherited, usually `device.mk`.
+- Device SELinux policy sources, including `audioserver.te`.
+- The `libviperaidl` module available elsewhere in the build tree.
 
-    allow audioserver unlabeled:file { read write open getattr };
-    allow hal_audio_default hal_audio_default:process { execmem };
-    ```
+## Integration steps
+
+### 1. Place the package in the source tree
+
+Clone or copy this repository into the Android source tree at:
+
+```text
+packages/apps/ViPER4AndroidFX
+```
+
+The path matters because `config.mk` declares `BUILD_PATH := packages/apps/ViPER4AndroidFX` and adds that path to `PRODUCT_SOONG_NAMESPACES`.
+
+### 2. Inherit the product configuration
+
+Add the package configuration to your device or product makefile, usually `device.mk`:
+
+```makefile
+$(call inherit-product, packages/apps/ViPER4AndroidFX/config.mk)
+```
+
+This adds the following modules to the product:
+
+- `ViPER4AndroidFX`
+- `libv4a_re`
+
+It also adds this directory to `PRODUCT_SOONG_NAMESPACES` and enables `RELAX_USES_LIBRARY_CHECK`.
+
+### 3. Verify the external dependency
+
+`libv4a_re` declares `libviperaidl` as a required module in `Android.bp`.
+
+Before building, confirm that your ROM tree already provides `libviperaidl`. If it does not, add the missing module from the ROM/device source that normally provides ViPER audio support.
+
+### 4. Add SELinux policy
+
+Add the following rules to your device `audioserver.te` policy file:
+
+```te
+get_prop(audioserver, vendor_audio_prop) # If Google or MTK device skip line
+
+allow audioserver unlabeled:file { read write open getattr };
+allow hal_audio_default hal_audio_default:process { execmem };
+```
+
+Depending on your device tree and Android version, these rules may need to be adapted to satisfy existing neverallow rules or vendor policy constraints.
+
+### 5. Build the modules
+
+From the root of the Android source tree, initialize the build environment and select your target:
+
+```sh
+source build/envsetup.sh
+lunch <target>
+```
+
+Then build the package modules directly:
+
+```sh
+mka ViPER4AndroidFX libv4a_re
+```
+
+Alternatively, build your normal ROM target after inheriting `config.mk`.
+
+### 6. Verify install locations
+
+After a successful build, verify that the product output includes:
+
+- `ViPER4AndroidFX.apk` as a system app.
+- `libv4a_re.so` under the vendor sound effects library path for both supported ABIs.
+
+The prebuilt APK is signed with its existing certificate, so the module uses `LOCAL_CERTIFICATE := PRESIGNED`.
+
+## Notes
+
+- This is not a Gradle/Android Studio project and does not build a new APK from source.
+- `ViPER4AndroidFX` overrides `AudioFX` through `LOCAL_OVERRIDES_PACKAGES := AudioFX`.
+- The native effect library is installed as a vendor module using Soong and is built for both 32-bit and 64-bit targets.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## ViPER4Android FX
+﻿## ViPER4Android FX
 
-This repository contains prebuilt ViPER4Android FX artifacts for integration into an AOSP-based ROM build tree.
+This repository contains prebuilt ViPER4Android FX artifacts for integration into an AOSP-based or custom Android ROM build tree.
 
 It provides:
 
@@ -12,7 +12,7 @@ It provides:
 - A working AOSP or custom ROM source tree.
 - This repository checked out at `packages/apps/ViPER4AndroidFX`.
 - A product or device makefile where product packages can be inherited, usually `device.mk`.
-- Device SELinux policy sources, including `audioserver.te`.
+- Device SELinux policy sources, usually under a device `sepolicy` directory.
 - The `libviperaidl` module available elsewhere in the build tree.
 
 ## Integration steps
@@ -29,35 +29,108 @@ The path matters because `config.mk` declares `BUILD_PATH := packages/apps/ViPER
 
 ### 2. Inherit the product configuration
 
-Add the package configuration to your device or product makefile, usually `device.mk`:
+Add the package configuration to your device or product makefile, usually `device/<vendor>/<device>/device.mk`:
 
 ```makefile
 $(call inherit-product, packages/apps/ViPER4AndroidFX/config.mk)
 ```
 
-This adds the following modules to the product:
+The included `config.mk` adds:
+
+```makefile
+PRODUCT_SOONG_NAMESPACES += \
+    packages/apps/ViPER4AndroidFX
+
+PRODUCT_PACKAGES += \
+    ViPER4AndroidFX \
+    libv4a_re
+
+RELAX_USES_LIBRARY_CHECK := true
+```
+
+### 3. Verify build dependencies and prebuilts
+
+The ROM tree must be able to build or provide these modules:
 
 - `ViPER4AndroidFX`
 - `libv4a_re`
+- `libviperaidl`
 
-It also adds this directory to `PRODUCT_SOONG_NAMESPACES` and enables `RELAX_USES_LIBRARY_CHECK`.
+`ViPER4AndroidFX` is a presigned prebuilt APK from:
 
-### 3. Verify the external dependency
+```text
+system/app/ViPER4AndroidFX/ViPER4AndroidFX.apk
+```
 
-`libv4a_re` declares `libviperaidl` as a required module in `Android.bp`.
+It overrides the stock `AudioFX` package through `LOCAL_OVERRIDES_PACKAGES := AudioFX` in `system/app/Android.mk`.
 
-Before building, confirm that your ROM tree already provides `libviperaidl`. If it does not, add the missing module from the ROM/device source that normally provides ViPER audio support.
+`libv4a_re` is declared as a prebuilt shared vendor library and depends on standard system shared libraries:
+
+- `liblog`
+- `libm`
+- `libdl`
+- `libc`
+
+The prebuilt audio effect libraries must exist at:
+
+```text
+vendor/lib/soundfx/libv4a_re.so
+vendor/lib64/soundfx/libv4a_re.so
+```
+
+The module installs them to the vendor `soundfx` path through:
+
+```bp
+vendor: true
+relative_install_path: "soundfx"
+compile_multilib: "both"
+```
 
 ### 4. Add SELinux policy
 
-Add the following rules to your device `audioserver.te` policy file:
+Do not run the SELinux rules in a host shell. They are Android SELinux policy statements and must be added to the device sepolicy used by the ROM build.
+
+#### Option 1: Copy the provided policy snippet
+
+Copy the provided policy file into your device sepolicy tree:
+
+```text
+packages/apps/ViPER4AndroidFX/sepolicy/audioserver_viper4android.te
+```
+
+For example:
+
+```text
+device/<vendor>/<device>/sepolicy/vendor/audioserver_viper4android.te
+```
+
+Then ensure the device sepolicy directory is included by the device tree, commonly in `BoardConfig.mk` or `BoardConfigCommon.mk`:
+
+```makefile
+BOARD_VENDOR_SEPOLICY_DIRS += \
+    device/<vendor>/<device>/sepolicy/vendor
+```
+
+Use `BOARD_SEPOLICY_DIRS` instead if your ROM/device tree still uses a non-vendor sepolicy layout.
+
+#### Option 2: Add the rules to an existing `audioserver.te`
+
+If your device tree already has an `audioserver.te`, add:
 
 ```te
-get_prop(audioserver, vendor_audio_prop) # If Google or MTK device skip line
+get_prop(audioserver, vendor_audio_prop)
 
-allow audioserver unlabeled:file { read write open getattr };
-allow hal_audio_default hal_audio_default:process { execmem };
+allow audioserver unlabeled:file {
+    getattr
+    open
+    read
+    write
+};
+
+allow hal_audio_default hal_audio_default:process execmem;
 ```
+
+For Google or MTK devices, skip `get_prop(audioserver, vendor_audio_prop)` if the device tree already grants the required vendor audio property access.
 
 Depending on your device tree and Android version, these rules may need to be adapted to satisfy existing neverallow rules or vendor policy constraints.
 
@@ -86,6 +159,18 @@ After a successful build, verify that the product output includes:
 - `libv4a_re.so` under the vendor sound effects library path for both supported ABIs.
 
 The prebuilt APK is signed with its existing certificate, so the module uses `LOCAL_CERTIFICATE := PRESIGNED`.
+
+## Integration checklist
+
+1. Put this module at `packages/apps/ViPER4AndroidFX`.
+2. Add the `inherit-product` line to `device.mk`.
+3. Confirm `PRODUCT_PACKAGES` includes `ViPER4AndroidFX` and `libv4a_re` through `config.mk`.
+4. Confirm `system/app/ViPER4AndroidFX/ViPER4AndroidFX.apk` exists.
+5. Confirm `vendor/lib/soundfx/libv4a_re.so` and `vendor/lib64/soundfx/libv4a_re.so` exist.
+6. Confirm `libviperaidl` is available in the ROM tree.
+7. Add the SELinux rules through the provided policy file or an existing `audioserver.te`.
+8. Ensure the device sepolicy directory is referenced by `BOARD_VENDOR_SEPOLICY_DIRS` or `BOARD_SEPOLICY_DIRS`.
+9. Build the ROM and verify that `libv4a_re.so` is installed under the vendor `soundfx` directory.
 
 ## Notes
 

--- a/sepolicy/audioserver_viper4android.te
+++ b/sepolicy/audioserver_viper4android.te
@@ -1,0 +1,24 @@
+# SELinux policy additions for integrating ViPER4AndroidFX into a custom ROM.
+#
+# Copy these rules into the device sepolicy tree, or include this file from a
+# device-specific sepolicy directory that is referenced by BOARD_SEPOLICY_DIRS.
+# These are policy statements for the Android build system; do not run them in a
+# host shell such as PowerShell, bash, or cmd.exe.
+
+# Allow audioserver to read vendor audio properties.
+# Skip this line for Google or MTK devices if the device tree already provides
+# the required vendor audio property access.
+get_prop(audioserver, vendor_audio_prop)
+
+# Allow audioserver to access files that the ViPER4AndroidFX audio effect may
+# expose without a more specific label on some device trees.
+allow audioserver unlabeled:file {
+    getattr
+    open
+    read
+    write
+};
+
+# Required by the prebuilt ViPER4AndroidFX audio effect on device trees where
+# the default audio HAL domain needs executable memory for this effect library.
+allow hal_audio_default hal_audio_default:process execmem;


### PR DESCRIPTION
## Summary
- Expand the ViPER4AndroidFX integration documentation for AOSP/custom ROM trees
- Add a reusable SELinux policy snippet for audioserver/audio HAL integration
- Replace the invalid generic Makefile CI workflow with validation for this prebuilt Android package

## Verification
- Confirmed required package files are present locally
- Confirmed APK and native library file signatures locally
- Confirmed stale Makefile workflow commands were removed

Co-Authored-By: Oz <oz-agent@warp.dev>